### PR TITLE
#169822910 add test of forget and reset password endpoints

### DIFF
--- a/test/asset/user.js
+++ b/test/asset/user.js
@@ -46,6 +46,14 @@ const userData = {
     email: 'admin@gmail.com',
     password: 'iamadmin',
   },
+  validPassword: {
+    password: 'newpassword',
+    confirmPassword: 'newpassword',
+  },
+  invalidPassword: {
+    password: 'newpassword',
+    confirmPassword: 'fakepassword',
+  },
 
 };
 export default userData;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -9,6 +9,8 @@ import getSingleReportTest from './reports/singleReport.test';
 import deleteReportTest from './reports/deleteReport.test';
 import changeStatusTest from './reports/changeStatus.test';
 import getUsersTest from './user/users.test';
+import forgetPasswordTest from './user/forgetPassword';
+import resetPasswordTest from './user/resetPassword';
 
 describe('System should run perfect', () => {
   describe('User signup', signupTest);
@@ -21,4 +23,6 @@ describe('System should run perfect', () => {
   describe('Delete specific report', deleteReportTest);
   describe('Admin change status', changeStatusTest);
   describe('List of users', getUsersTest);
+  describe('Forget password', forgetPasswordTest);
+  describe('Reset password', resetPasswordTest);
 });

--- a/test/user/forgetPassword.js
+++ b/test/user/forgetPassword.js
@@ -1,0 +1,43 @@
+import { it } from 'mocha';
+import chai, { request, expect } from 'chai';
+import http from 'chai-http';
+import app from '../../server';
+
+chai.use(http);
+
+const forgetPasswordTest = () => {
+  it('User should not forget password if he doesn\'t provide email', (done) => {
+    request(app)
+      .post('/api/v1/auth/forget')
+      .end((err, res) => {
+        expect(res).to.have.status(400);
+        expect(res.body).to.have.a.property('status', 400);
+        expect(res.body).to.have.a.property('error');
+        done();
+      });
+  });
+  it('User should not forget password if he is not registered', (done) => {
+    request(app)
+      .post('/api/v1/auth/forget')
+      .send('email', 'example@ex.com')
+      .end((err, res) => {
+        expect(res).to.have.status(404);
+        expect(res.body).to.have.a.property('status', 404);
+        expect(res.body).to.have.a.property('error');
+        done();
+      });
+  });
+  it('User should get token to reset password on email if he is registered', (done) => {
+    request(app)
+      .post('/api/v1/auth/forget')
+      .send('email', 'oscarmugenzi@gmail.com')
+      .end((err, res) => {
+        expect(res).to.have.status(200);
+        expect(res.body).to.have.a.property('status', 200);
+        expect(res.body).to.have.a.property('message');
+        done();
+      });
+  });
+};
+
+export default forgetPasswordTest;

--- a/test/user/resetPassword.js
+++ b/test/user/resetPassword.js
@@ -1,0 +1,59 @@
+import { it } from 'mocha';
+import chai, { request, expect } from 'chai';
+import http from 'chai-http';
+import app from '../../server';
+import reportData from '../asset/report';
+import userData from '../asset/user';
+
+chai.use(http);
+
+const resetPasswordTest = () => {
+  it('User should not reset password if He doesn\'t provide token', (done) => {
+    request(app)
+      .patch('/api/v1/auth/reset')
+      .send(userData.validPassword)
+      .end((err, res) => {
+        expect(res).to.have.status(401);
+        expect(res.body).to.have.a.property('status', 401);
+        expect(res.body).to.have.a.property('error');
+        done();
+      });
+  });
+  it('User should not reset password if He provide invalid token', (done) => {
+    request(app)
+      .patch('/api/v1/auth/reset')
+      .set(reportData.invalidToken)
+      .send(userData.validPassword)
+      .end((err, res) => {
+        expect(res).to.have.status(401);
+        expect(res.body).to.have.a.property('status', 401);
+        expect(res.body).to.have.a.property('error');
+        done();
+      });
+  });
+  it('User should not reset password if He provide mismatch password (password doesn\'t match) ', (done) => {
+    request(app)
+      .patch('/api/v1/auth/reset')
+      .set(reportData.validToken)
+      .send(userData.invalidPassword)
+      .end((err, res) => {
+        expect(res).to.have.status(400);
+        expect(res.body).to.have.a.property('status', 400);
+        expect(res.body).to.have.a.property('error');
+        done();
+      });
+  });
+  it('User should reset password if He provide valid token and matched password ', (done) => {
+    request(app)
+      .patch('/api/v1/auth/reset')
+      .set(reportData.validToken)
+      .send(userData.validPassword)
+      .end((err, res) => {
+        expect(res).to.have.status(200);
+        expect(res.body).to.have.a.property('status', 200);
+        expect(res.body).to.have.a.property('message');
+        done();
+      });
+  });
+};
+export default resetPasswordTest;


### PR DESCRIPTION
#### What does this PR do?
have test of forget and reset password endpoints
#### Description of Task to be completed?
create test of two endpoints:
 - POST /api/v1/auth/forget   Forget password
 - PATCH /api/v1/auth/reset   Reset password
#### How should this be manually tested?
clone repo, cd into it and run these comands:
 - npm install
 - npm test
#### What are the relevant pivotal tracker stories?
#169822910