### PR TITLE
#169822910 correct test of forget and reset password endpoints

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "test"
   },
   "scripts": {
-    "test": "nyc --reporter=html --reporter=text mocha --require babel-core/register --require babel-polyfill --exit ./test/index.test.js",
+    "test": "nyc --reporter=html --reporter=text mocha  --timeout 5000 --require babel-core/register --require babel-polyfill --exit ./test/index.test.js",
     "coverage": "nyc report --reporter=text-lcov | coveralls",
     "dev": "nodemon --require babel-core/register --require babel-polyfill ./server/index.js",
     "start": "node --require babel-core/register --require babel-polyfill ./server/index.js"
@@ -40,6 +40,7 @@
     "babel-preset-env": "^1.7.0",
     "bcrypt": "^3.0.6",
     "body-parser": "^1.19.0",
+    "compression": "1.7.4",
     "dotenv": "^8.2.0",
     "express": "^4.17.1",
     "express-fileupload": "^1.1.6-alpha.6",

--- a/test/asset/user.js
+++ b/test/asset/user.js
@@ -54,6 +54,7 @@ const userData = {
     password: 'newpassword',
     confirmPassword: 'fakepassword',
   },
+  resetToken: 'clementmistico@gmail.com/eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6ImNsZW1lbnRtaXN0aWNvQGdtYWlsLmNvbSIsInVzZXJuYW1lIjoiTWlzdGljbyIsImlkIjo1LCJpc0FkbWluIjp0cnVlLCJpYXQiOjE1NzQxNzMxNzcsImV4cCI6MTU3NDI1OTU3NywiaXNzIjoid3d3Lmp3dC5pbyJ9.XDVnP2S0d2jwz7gylEMZFwcbv8okXEcj2AIFDMXuFb4',
 
 };
 export default userData;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -9,8 +9,8 @@ import getSingleReportTest from './reports/singleReport.test';
 import deleteReportTest from './reports/deleteReport.test';
 import changeStatusTest from './reports/changeStatus.test';
 import getUsersTest from './user/users.test';
-import forgetPasswordTest from './user/forgetPassword';
-import resetPasswordTest from './user/resetPassword';
+import forgetPasswordTest from './user/forgetPassword.test';
+import resetPasswordTest from './user/resetPassword.test';
 
 describe('System should run perfect', () => {
   describe('User signup', signupTest);

--- a/test/user/forgetPassword.test.js
+++ b/test/user/forgetPassword.test.js
@@ -19,7 +19,7 @@ const forgetPasswordTest = () => {
   it('User should not forget password if he is not registered', (done) => {
     request(app)
       .post('/api/v1/auth/forget')
-      .send('email', 'example@ex.com')
+      .send({ email: 'example@ex.com' })
       .end((err, res) => {
         expect(res).to.have.status(404);
         expect(res.body).to.have.a.property('status', 404);
@@ -30,7 +30,7 @@ const forgetPasswordTest = () => {
   it('User should get token to reset password on email if he is registered', (done) => {
     request(app)
       .post('/api/v1/auth/forget')
-      .send('email', 'oscarmugenzi@gmail.com')
+      .send({ email: 'clementmistico@gmail.com' })
       .end((err, res) => {
         expect(res).to.have.status(200);
         expect(res.body).to.have.a.property('status', 200);

--- a/test/user/resetPassword.test.js
+++ b/test/user/resetPassword.test.js
@@ -8,21 +8,9 @@ import userData from '../asset/user';
 chai.use(http);
 
 const resetPasswordTest = () => {
-  it('User should not reset password if He doesn\'t provide token', (done) => {
+  it('User should not reset password if He provide invalid or expired link', (done) => {
     request(app)
-      .patch('/api/v1/auth/reset')
-      .send(userData.validPassword)
-      .end((err, res) => {
-        expect(res).to.have.status(401);
-        expect(res.body).to.have.a.property('status', 401);
-        expect(res.body).to.have.a.property('error');
-        done();
-      });
-  });
-  it('User should not reset password if He provide invalid token', (done) => {
-    request(app)
-      .patch('/api/v1/auth/reset')
-      .set(reportData.invalidToken)
+      .patch(`/api/v1/auth/reset/clementmistico@gmail.com/${reportData.invalidToken}`)
       .send(userData.validPassword)
       .end((err, res) => {
         expect(res).to.have.status(401);
@@ -33,8 +21,7 @@ const resetPasswordTest = () => {
   });
   it('User should not reset password if He provide mismatch password (password doesn\'t match) ', (done) => {
     request(app)
-      .patch('/api/v1/auth/reset')
-      .set(reportData.validToken)
+      .patch(`/api/v1/auth/reset/${userData.resetToken}`)
       .send(userData.invalidPassword)
       .end((err, res) => {
         expect(res).to.have.status(400);
@@ -45,8 +32,7 @@ const resetPasswordTest = () => {
   });
   it('User should reset password if He provide valid token and matched password ', (done) => {
     request(app)
-      .patch('/api/v1/auth/reset')
-      .set(reportData.validToken)
+      .patch(`/api/v1/auth/reset/${userData.resetToken}`)
       .send(userData.validPassword)
       .end((err, res) => {
         expect(res).to.have.status(200);


### PR DESCRIPTION
#### What does this PR do?
Have clear test of forget and reset password endpoints
#### Description of Task to be completed?
correct some errors and unnecessary test in the following endpoints:
 - POST /api/v1/auth/forget
 - PATCH /api/v1/auth/reset/:email/:token
#### How should this be manually tested?
clone this repo, cd into it, run these commands:
 - npm install
 - npm test
#### What are the relevant pivotal tracker stories?
#169822910