### PR TITLE
#169826584 Add endpoints used to reset user password

### DIFF
--- a/server/controllers/forgetpassword.js
+++ b/server/controllers/forgetpassword.js
@@ -1,0 +1,41 @@
+import notification from '../modals/notification';
+import emailValidator from '../helpers/emailValidation';
+import userModal from '../modals/userModal';
+
+const doAction = async (req, res) => {
+  try {
+    const isExist = userModal.findUser(req.body.email);
+    const token = await userModal.generateResetToken(isExist, isExist.password);
+    const url = `https://localhost:5000/api/v1/auth/reset/${isExist.email}/${token}`;
+    const msg = `You requested for a password reset, kindly use this link ${url} to reset your password`;
+    await notification.sendEmail(isExist, msg);
+    return res.status(200).json({
+      status: 200,
+      message: 'Link to reset password sent to your email',
+    });
+  } catch (err) {
+    return res.status(500).json({
+      status: 500,
+      error: 'Server error',
+    });
+  }
+};
+const forgotPassword = async (req, res) => {
+  const { error } = emailValidator(req.body);
+  if (error) {
+    return res.status(400).json({
+      status: 400,
+      error: error.details[0].message,
+    });
+  }
+  const isExist = userModal.findUser(req.body.email);
+  if (!isExist) {
+    return res.status(404).json({
+      status: 404,
+      error: 'Email not found',
+    });
+  }
+  await doAction(req, res);
+  return {};
+};
+export default forgotPassword;

--- a/server/controllers/resetpassword.js
+++ b/server/controllers/resetpassword.js
@@ -1,0 +1,25 @@
+import userModal from '../modals/userModal';
+
+const resetPassword = async (req, res) => {
+  const { password, confirmPassword } = req.body;
+  if (!password || password.length < 6) {
+    return res.status(400).json({
+      status: 400,
+      error: 'Password must be atleast 6 characters long',
+    });
+  }
+  if (password !== confirmPassword) {
+    return res.status(400).json({
+      status: 400,
+      error: 'Password doesn\'t match',
+    });
+  }
+  const user = userModal.findUser(req.user.email);
+  const newPassword = await userModal.hashPassword(password);
+  user.password = newPassword;
+  return res.status(200).json({
+    status: 200,
+    message: 'Password updated successfully',
+  });
+};
+export default resetPassword;

--- a/server/helpers/emailValidation.js
+++ b/server/helpers/emailValidation.js
@@ -1,0 +1,9 @@
+import joi from 'joi';
+
+const emailValidator = (input) => {
+  const emailSchema = {
+    email: joi.string().email().required(),
+  };
+  return joi.validate(input, emailSchema);
+};
+export default emailValidator;

--- a/server/index.js
+++ b/server/index.js
@@ -4,6 +4,7 @@ import bodyParser from 'body-parser';
 import fileupload from 'express-fileupload';
 import { serve, setup } from 'swagger-ui-express';
 import env from 'dotenv';
+import compression from 'compression';
 import routes from './routes';
 import swaggerDoc from '../swagger.json';
 
@@ -12,6 +13,7 @@ const app = express();
 const port = process.env.PORT || 3000;
 
 app.use(helmet());
+app.use(compression());
 app.use(fileupload({ createParentPath: true }));
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: true }));

--- a/server/middleware/reset.js
+++ b/server/middleware/reset.js
@@ -1,0 +1,26 @@
+import jwt from 'jsonwebtoken';
+import userModal from '../modals/userModal';
+
+const verifyToken = (req, res, next) => {
+  const { email, token } = req.params;
+  if (!email || !token) {
+    return res.status(401).json({
+      status: 401,
+      error: 'Invalid reset password link or link has expired',
+    });
+  }
+  try {
+    const user = userModal.findUser(email);
+    const secret = user.password;
+    const options = { expiresIn: '1d', issuer: 'www.jwt.io' };
+    const decoded = jwt.verify(token, secret, options);
+    req.user = decoded;
+    return next();
+  } catch (err) {
+    return res.status(401).json({
+      status: 401,
+      error: 'Invalid reset password link or link has expired',
+    });
+  }
+};
+export default verifyToken;

--- a/server/modals/userModal.js
+++ b/server/modals/userModal.js
@@ -7,6 +7,7 @@ class UserModal {
   constructor() {
     this.user = users;
     this.report = reportData;
+    this.options = { expiresIn: '1d', issuer: 'www.jwt.io' };
   }
 
   findUser(email) {
@@ -47,6 +48,21 @@ class UserModal {
       this.salt = await bcrypt.genSalt(10);
       this.passHash = await bcrypt.hash(password, this.salt);
       return this.passHash;
+    } catch (err) {
+      return err;
+    }
+  }
+
+  generateResetToken(info, secret) {
+    try {
+      const payload = {
+        email: info.email,
+        username: info.username,
+        id: info.id,
+        isAdmin: info.isAdmin,
+      };
+      const token = jwt.sign(payload, secret, this.options);
+      return token;
     } catch (err) {
       return err;
     }

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -12,6 +12,9 @@ import newRecord from '../controllers/createRecord';
 import getUsers from '../controllers/getUsers';
 import grantAccess from '../middleware/access';
 import isAdmin from '../middleware/admin';
+import forgotPassword from '../controllers/forgetpassword';
+import verifyAuth from '../middleware/reset';
+import resetPassword from '../controllers/resetpassword';
 
 const routes = express.Router();
 
@@ -25,5 +28,7 @@ routes.patch('/red-flags/:red_Flag_Id/comment', [userAuthentication, grantAccess
 routes.delete('/red-flags/:red_Flag_Id', [userAuthentication, grantAccess], deleteRecord);
 routes.patch('/red-flags/:red_Flag_Id/status', [userAuthentication, isAdmin], changeStatus);
 routes.post('/red-flags', userAuthentication, newRecord);
+routes.post('/auth/forget', forgotPassword);
+routes.patch('/auth/reset/:email/:token', verifyAuth, resetPassword);
 
 export default routes;


### PR DESCRIPTION
#### What does this PR do?
Have forgot and reset password endpoints working
#### Description of Task to be completed?
create the following endpoints:
 - POST /ap1/v1/auth/forget
 - PATCH /api/v1/auth/reset/<email>/<token>
#### How should this be manually tested?
clone this repo,cd into it, run the following commands:
 - npm install
 - npm start
Then post email in the forget endpoint above you will get email gives you link to follow
#### What are the relevant pivotal tracker stories?
#169826584
![reset](https://user-images.githubusercontent.com/50277906/69169402-fa920300-0b00-11ea-99d9-4dc608191556.PNG)